### PR TITLE
Build with servant 0.14 

### DIFF
--- a/src/Servant/Subscriber/Subscribable.hs
+++ b/src/Servant/Subscriber/Subscribable.hs
@@ -88,5 +88,5 @@ instance HasForeign lang ftype sublayout => HasForeign lang ftype (Subscribable 
                                           req & reqFuncName . _FunctionName %~ ("" :) -- Prepend empty string for marking as subscribable.
 
 instance HasLink sub => HasLink (Subscribable :> sub) where
-    type MkLink (Subscribable :> sub) = MkLink sub
-    toLink _ = toLink (Proxy :: Proxy sub)
+    type MkLink (Subscribable :> sub) a = MkLink sub a
+    toLink toA _ = toLink toA (Proxy :: Proxy sub)

--- a/src/Servant/Subscriber/Types.hs
+++ b/src/Servant/Subscriber/Types.hs
@@ -20,7 +20,7 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           GHC.Generics
 import           Network.URI (URI (..), pathSegments, unEscapeString)
-import           Servant.Utils.Links (IsElem, HasLink, MkLink, safeLink)
+import           Servant.Links (IsElem, HasLink, MkLink, safeLink, Link)
 import           System.FilePath.Posix (splitPath)
 import Debug.Trace (trace)
 
@@ -89,11 +89,12 @@ notify :: forall api endpoint. (IsElem endpoint api, HasLink endpoint
   => Subscriber api
   -> Event
   -> Proxy endpoint
-  -> (MkLink endpoint -> URI)
+  -> (MkLink endpoint Link -> URI)
   -> STM ()
 notify subscriber event pEndpoint getLink = do
   let mkPath = Path . map (T.pack . unEscapeString) . pathSegments . getLink
-  let resource = mkPath $ safeLink (Proxy :: Proxy api) pEndpoint
+  let sLink  = safeLink (Proxy :: Proxy api) pEndpoint
+  let resource = mkPath $ sLink
   trace ("NOTIFIED PATH:" <> show resource) (pure ())
   modifyState event resource subscriber
 
@@ -103,7 +104,7 @@ notifyIO :: forall api endpoint. (IsElem endpoint api, HasLink endpoint
   => Subscriber api
   -> Event
   -> Proxy endpoint
-  -> (MkLink endpoint -> URI)
+  -> (MkLink endpoint Link -> URI)
   -> IO ()
 notifyIO subscriber event pEndpoint getLink = atomically $ notify subscriber event pEndpoint getLink
 


### PR DESCRIPTION
Add the missing target type to HasLink.

Fixes #17 

I've tested that it builds some purescript that compiles, but not in a real scenario.

If I'm honest I'm not entirely sure I should be using the Link type directly.

I thought I'd open a PR in case this is useful to someone.  