### PR TITLE
Support servant-0.17

### DIFF
--- a/servant-subscriber.cabal
+++ b/servant-subscriber.cabal
@@ -50,7 +50,7 @@ library
                      , monad-control
                      , monad-logger
                      , network-uri
-                     , servant >= 0.14
+                     , servant >= 0.14.1
                      , servant-foreign
                      , servant-server
                      , stm

--- a/src/Servant/Subscriber.hs
+++ b/src/Servant/Subscriber.hs
@@ -35,7 +35,7 @@ import           Network.Wai.Handler.WebSockets
 import           Network.WebSockets.Connection   as WS
 import           Servant.Server
 import           Servant.Subscriber.Subscribable
-import           Servant.Utils.Links             (HasLink, IsElem, MkLink,
+import           Servant.Links                   (HasLink, IsElem, MkLink,
                                                   safeLink)
 
 import           Servant.Subscriber.Backend.Wai  ()


### PR DESCRIPTION
`Servant.Utils.Links` [was moved](https://github.com/haskell-servant/servant/blob/master/servant/CHANGELOG.md#0141) to `Servant.Links` in `servant-0.14.1`.

I've taken the route of bumping the lower bound on `servant` from `0.14` to `0.14.1`, rather than implementing a conditional check on the version in the code.

This is [currently blocking](https://github.com/commercialhaskell/stackage/issues/5191) inclusion of `servant-0.17` in the latest stackage 